### PR TITLE
Look through all extenders

### DIFF
--- a/snxconnect.py
+++ b/snxconnect.py
@@ -262,15 +262,17 @@ class HTMLRequester(object):
             connecting the VPN. This information then passed to the snx
             program via a socket.
         """
+        extender_found = False
         for script in self.soup.find_all('script'):
-            if '/* Extender.user_name' in script.text:
+            if script.string and '/* Extender.user_name' in script.string:
+                extender_found = True
                 break
-        else:
+        if not extender_found:
             print("Error retrieving extender variables")
             return
 
         match_line = None
-        for line in script.text.split('\n'):
+        for line in script.string.split('\n'):
             if '/* Extender.user_name' in line:
                 match_line = line
                 break
@@ -426,6 +428,8 @@ def main():
     result = rq.login()
     if result:
         rq.call_snx()
+    else:
+        print('Failed to login')
 
 
 # end def main ()


### PR DESCRIPTION
On newer installations we are getting error:

> Error retrieving extender variables
Traceback (most recent call last):
  File "snxconnect.py", line 428, in <module>
    main()
  File "snxconnect.py", line 420, in main
    result = rq.login()
  File "snxconnect.py", line 205, in login
    self.generate_snx_info()
  File "snxconnect.py", line 112, in generate_snx_info
    gw_ip = socket.gethostbyname(self.extender_vars['host_name'])
AttributeError: 'HTMLRequester' object has no attribute 'extender_vars'

Looking through script and using `string` instead of `text` fixes the problem.